### PR TITLE
BUGFIX validating credential name mutations

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -46,11 +46,7 @@ func (g *GatewayMutationHook) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	gateway, err = mutate(ctx, gateway.DeepCopy())
-	if err != nil {
-		log.Error(err, fmt.Sprintf("failed to mutate gateway: %s", gateway.Name))
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
+	gateway = mutate(ctx, gateway.DeepCopy())
 
 	jsonGateway, err := json.Marshal(gateway)
 	if err != nil {
@@ -80,7 +76,7 @@ func credentialName(ctx context.Context, namespace, name string, portName string
 	return fmt.Sprintf("%s-%s", prefix, portName)
 }
 
-func mutate(ctx context.Context, gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
+func mutate(ctx context.Context, gateway *v1beta1.Gateway) *v1beta1.Gateway {
 	log := log.FromContext(ctx)
 
 	for _, s := range gateway.Spec.Servers {
@@ -95,5 +91,5 @@ func mutate(ctx context.Context, gateway *v1beta1.Gateway) (*v1beta1.Gateway, er
 		}
 	}
 
-	return gateway, nil
+	return gateway
 }

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -10,12 +10,10 @@ import (
 	networkingv1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -74,73 +72,22 @@ func (g *GatewayMutationHook) InjectDecoder(d *admission.Decoder) error {
 	return nil
 }
 
-func credentialName(ctx context.Context, namespace, name string) string {
+func credentialName(ctx context.Context, namespace, name string, portName string) string {
 	log := log.FromContext(ctx)
-
 	prefix := fmt.Sprintf("%s-%s", namespace, name)
-	randomStr := rand.String(credentialNameRandomStrLen)
-
 	// Leave enough space for a dash and the random string
-	maxPrefixLen := secretNameMaxLength - credentialNameRandomStrLen - 1
+	maxPrefixLen := secretNameMaxLength - len(portName) - 1
 
 	if len(prefix) > maxPrefixLen {
 		prefix = prefix[:maxPrefixLen]
 		log.Info(fmt.Sprintf("truncating gateway %s credentialName to %s", name, prefix))
 	}
 
-	return fmt.Sprintf("%s-%s", prefix, randomStr)
-}
-
-func getGatewayServerByPortName(name string, gateway *v1beta1.Gateway) *networkingv1beta1.Server {
-	for _, s := range gateway.Spec.Servers {
-		if s.Port.Name == name {
-			return s
-		}
-	}
-	return nil
-}
-
-func getLastAppliedGateway(gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
-	var lastAppliedGateway *v1beta1.Gateway = nil
-	if gateway.Annotations != nil {
-		if js, ok := gateway.Annotations[lastAppliedMutationAnnotation]; ok {
-			lastAppliedGateway = &v1beta1.Gateway{}
-			if err := yaml.Unmarshal([]byte(js), lastAppliedGateway); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return lastAppliedGateway, nil
-}
-
-func annotateMutation(gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
-	ncs, err := yaml.Marshal(gateway)
-	if err != nil {
-		return nil, err
-	}
-	jsb, err := yaml.YAMLToJSON(ncs)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if gateway.Annotations == nil {
-		gateway.Annotations = map[string]string{}
-	}
-
-	gateway.Annotations[lastAppliedMutationAnnotation] = string(jsb)
-	return gateway, nil
+	return fmt.Sprintf("%s-%s", prefix, portName)
 }
 
 func mutate(ctx context.Context, gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
 	log := log.FromContext(ctx)
-
-	lastAppliedGateway, err := getLastAppliedGateway(gateway)
-	if err != nil {
-		return nil, err
-	}
-
-	annotateLastApplied := false
 
 	for _, s := range gateway.Spec.Servers {
 		if s.Tls == nil {
@@ -148,29 +95,11 @@ func mutate(ctx context.Context, gateway *v1beta1.Gateway) (*v1beta1.Gateway, er
 		}
 
 		if s.Tls.Mode == networkingv1beta1.ServerTLSSettings_SIMPLE {
-			var shouldMutate bool = true
-
-			if lastAppliedGateway != nil {
-				if cs := getGatewayServerByPortName(s.Port.Name, lastAppliedGateway); cs != nil {
-					shouldMutate = false
-					s.Tls.CredentialName = cs.Tls.CredentialName
-				}
-			}
-
-			if shouldMutate {
-				annotateLastApplied = true
-				newCredentialName := credentialName(ctx, gateway.Namespace, gateway.Name)
-				log.Info(fmt.Sprintf("mutating gateway %s Tls.CredentialName, %s to %s", gateway.Name, s.Tls.CredentialName, newCredentialName))
-				s.Tls.CredentialName = newCredentialName
-			}
+			newCredentialName := credentialName(ctx, gateway.Namespace, gateway.Name, s.Port.Name)
+			log.Info(fmt.Sprintf("mutating gateway %s Tls.CredentialName, %s to %s", gateway.Name, s.Tls.CredentialName, newCredentialName))
+			s.Tls.CredentialName = newCredentialName
 		}
 	}
 
-	if annotateLastApplied {
-		gateway, err = annotateMutation(gateway)
-		if err != nil {
-			return nil, err
-		}
-	}
 	return gateway, nil
 }

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/version"
 	networkingv1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -18,9 +19,12 @@ import (
 )
 
 const (
-	secretNameMaxLength           = 253
-	credentialNameRandomStrLen    = 10
-	lastAppliedMutationAnnotation = "v1beta1.kanopy-platform.github.io/last-applied-mutation"
+	secretNameMaxLength        = 253
+	credentialNameRandomStrLen = 10
+)
+
+var (
+	lastAppliedMutationAnnotation = fmt.Sprintf("%s/last-applied-mutation", version.String())
 )
 
 type GatewayMutationHook struct {

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -65,7 +65,7 @@ func (g *GatewayMutationHook) InjectDecoder(d *admission.Decoder) error {
 func credentialName(ctx context.Context, namespace, name string, portName string) string {
 	log := log.FromContext(ctx)
 	prefix := fmt.Sprintf("%s-%s", namespace, name)
-	// Leave enough space for a dash and the random string
+	// Leave enough space for dash before the portName suffix.
 	maxPrefixLen := secretNameMaxLength - len(portName) - 1
 
 	if len(prefix) > maxPrefixLen {

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/version"
 	networkingv1beta1 "istio.io/api/networking/v1beta1"
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
@@ -17,12 +16,7 @@ import (
 )
 
 const (
-	secretNameMaxLength        = 253
-	credentialNameRandomStrLen = 10
-)
-
-var (
-	lastAppliedMutationAnnotation = fmt.Sprintf("%s/last-applied-mutation", version.String())
+	secretNameMaxLength = 253
 )
 
 type GatewayMutationHook struct {

--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -18,8 +18,9 @@ import (
 )
 
 const (
-	secretNameMaxLength        = 253
-	credentialNameRandomStrLen = 10
+	secretNameMaxLength           = 253
+	credentialNameRandomStrLen    = 10
+	lastAppliedMutationAnnotation = "v1beta1.kanopy-platform.github.io/last-applied-mutation"
 )
 
 type GatewayMutationHook struct {
@@ -98,7 +99,7 @@ func getGatewayServerByPortName(name string, gateway *v1beta1.Gateway) *networki
 func getLastAppliedGateway(gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
 	var lastAppliedGateway *v1beta1.Gateway = nil
 	if gateway.Annotations != nil {
-		if js, ok := gateway.Annotations["v1beta1.kanopy-platform.github.io/last-applied-mutation"]; ok {
+		if js, ok := gateway.Annotations[lastAppliedMutationAnnotation]; ok {
 			lastAppliedGateway = &v1beta1.Gateway{}
 			if err := yaml.Unmarshal([]byte(js), lastAppliedGateway); err != nil {
 				return nil, err
@@ -123,7 +124,7 @@ func annotateMutation(gateway *v1beta1.Gateway) (*v1beta1.Gateway, error) {
 		gateway.Annotations = map[string]string{}
 	}
 
-	gateway.Annotations["v1beta1.kanopy-platform.github.io/last-applied-mutation"] = string(jsb)
+	gateway.Annotations[lastAppliedMutationAnnotation] = string(jsb)
 	return gateway, nil
 }
 
@@ -158,7 +159,6 @@ func mutate(ctx context.Context, gateway *v1beta1.Gateway) (*v1beta1.Gateway, er
 				log.Info(fmt.Sprintf("mutating gateway %s Tls.CredentialName, %s to %s", gateway.Name, s.Tls.CredentialName, newCredentialName))
 				s.Tls.CredentialName = newCredentialName
 			}
-
 		}
 	}
 

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -117,10 +117,9 @@ func TestMutate(t *testing.T) {
 
 	gateway := v1beta1.Gateway{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        "example-gateway",
-			Namespace:   "devops",
-			Labels:      map[string]string{"v1beta1.kanopy-platform.github.io/istio-cert-controller-inject-simple-credential-name": "true"},
-			Annotations: map[string]string{},
+			Name:      "example-gateway",
+			Namespace: "devops",
+			Labels:    map[string]string{"v1beta1.kanopy-platform.github.io/istio-cert-controller-inject-simple-credential-name": "true"},
 		},
 		Spec: networkingv1beta1.Gateway{
 			Servers: []*networkingv1beta1.Server{

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -85,33 +85,33 @@ func TestCredentialName(t *testing.T) {
 	t.Parallel()
 	const portName = "https"
 	tests := []struct {
-		description  string
-		namespace    string
-		name         string
-		wantContains string
-		wantLen      int
+		description string
+		namespace   string
+		name        string
+		want        string
+		wantLen     int
 	}{
 		{
-			description:  "generated credentialName within character limit",
-			namespace:    "devops",
-			name:         "example-gateway",
-			wantContains: fmt.Sprintf("devops-example-gateway-%s", portName),
-			wantLen:      28,
+			description: "generated credentialName within character limit",
+			namespace:   "devops",
+			name:        "example-gateway",
+			want:        fmt.Sprintf("devops-example-gateway-%s", portName),
+			wantLen:     28,
 		},
 		{
 			description: "generated credentialName is truncated",
 			namespace:   strings.Repeat("a", 125),
 			name:        strings.Repeat("b", 125),
 			// some characters from the end of name should be truncated
-			wantContains: fmt.Sprintf("%s-%s-%s", strings.Repeat("a", 125), strings.Repeat("b", 121), portName),
-			wantLen:      secretNameMaxLength,
+			want:    fmt.Sprintf("%s-%s-%s", strings.Repeat("a", 125), strings.Repeat("b", 121), portName),
+			wantLen: secretNameMaxLength,
 		},
 	}
 
 	for _, test := range tests {
 		n := credentialName(context.TODO(), test.namespace, test.name, portName)
 
-		assert.Contains(t, n, test.wantContains, test.description)
+		assert.Equal(t, n, test.want, test.description)
 		assert.Equal(t, test.wantLen, len(n), test.description)
 	}
 }

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -159,8 +159,7 @@ func TestMutate(t *testing.T) {
 		},
 	}
 
-	mutatedGateway, err := mutate(context.TODO(), gateway.DeepCopy())
-	assert.NoError(t, err)
+	mutatedGateway := mutate(context.TODO(), gateway.DeepCopy())
 
 	assert.Equal(t, gateway.Spec.Servers[0], mutatedGateway.Spec.Servers[0])
 	assert.Equal(t, gateway.Spec.Servers[1], mutatedGateway.Spec.Servers[1])

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -167,27 +167,3 @@ func TestMutate(t *testing.T) {
 	assert.Equal(t, gateway.Spec.Servers[2].Tls.Mode, mutatedGateway.Spec.Servers[2].Tls.Mode)
 	assert.NotEqual(t, gateway.Spec.Servers[2].Tls.CredentialName, mutatedGateway.Spec.Servers[2].Tls.CredentialName)
 }
-
-func gatewayWithCredentialName(name string) v1beta1.Gateway {
-	return v1beta1.Gateway{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      "example-gateway",
-			Namespace: "devops",
-			Labels:    map[string]string{"v1beta1.kanopy-platform.github.io/istio-cert-controller-inject-simple-credential-name": "true"},
-		},
-		Spec: networkingv1beta1.Gateway{
-			Servers: []*networkingv1beta1.Server{
-				{
-					Port: &networkingv1beta1.Port{
-						Number: 443,
-						Name:   "https",
-					},
-					Tls: &networkingv1beta1.ServerTLSSettings{
-						Mode:           networkingv1beta1.ServerTLSSettings_SIMPLE,
-						CredentialName: name,
-					},
-				},
-			},
-		},
-	}
-}

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -184,7 +184,7 @@ func TestMutate_AnnotatedWithLastAppliedMutation(t *testing.T) {
 	gateway := gatewayWithCredentialName("should-be-mutated")
 	mutatedGateway, err := mutate(context.TODO(), gateway.DeepCopy())
 	assert.NoError(t, err)
-	assert.Contains(t, mutatedGateway.Annotations, "v1beta1.kanopy-platform.github.io/last-applied-mutation")
+	assert.Contains(t, mutatedGateway.Annotations, lastAppliedMutationAnnotation)
 }
 
 func TestMutate_AnnotatedWithLastAppliedMutationIsGateway(t *testing.T) {
@@ -193,7 +193,7 @@ func TestMutate_AnnotatedWithLastAppliedMutationIsGateway(t *testing.T) {
 	mutatedGateway, err := mutate(context.TODO(), gateway.DeepCopy())
 	assert.NoError(t, err)
 	annotatedGateway := &v1beta1.Gateway{}
-	assert.NoError(t, yaml.Unmarshal([]byte(mutatedGateway.Annotations["v1beta1.kanopy-platform.github.io/last-applied-mutation"]), annotatedGateway))
+	assert.NoError(t, yaml.Unmarshal([]byte(mutatedGateway.Annotations[lastAppliedMutationAnnotation]), annotatedGateway))
 	mutatedGateway.Annotations = nil
 	assert.Equal(t, mutatedGateway, annotatedGateway)
 }
@@ -207,7 +207,7 @@ func TestMutate_AnnotatedWithLastAppliedMutationShouldNotMutate(t *testing.T) {
 	assert.NoError(t, err)
 
 	gateway.Annotations = map[string]string{
-		"v1beta1.kanopy-platform.github.io/last-applied-mutation": string(jsb),
+		lastAppliedMutationAnnotation: string(jsb),
 	}
 
 	mutatedGateway, err := mutate(context.TODO(), gateway.DeepCopy())


### PR DESCRIPTION
We missed an edge case that is causing the CredentialName to be mutated on any edit made to the Istio Gateway.
The mutation handler will rely on the following constraints:
- A Gateway will NOT have more than one server with the same Server.Port.Name

Given this constraint by the istio validating webhook the CredentialName can be of the form "namespace-gatewayName-portName"  e.g. "default-myGateway-https".