### PR TITLE
Bugfix: Gateway Reconcile when Certificate is not found

### DIFF
--- a/internal/controllers/v1beta1/gateway.go
+++ b/internal/controllers/v1beta1/gateway.go
@@ -127,9 +127,7 @@ func (c *GatewayController) Reconcile(ctx context.Context, request reconcile.Req
 					Requeue: true,
 				}, err
 			}
-		}
-
-		if cert != nil {
+		} else {
 			log.V(1).Info("Found certificate", "server", s)
 			if err := c.certHandler.UpdateCertificate(ctx, cert.DeepCopy(), gateway, s); err != nil {
 				return reconcile.Result{


### PR DESCRIPTION
```golang
cert, err := c.certClient.CertmanagerV1().Certificates(c.certificateNamespace).Get(ctx, s.Tls.CredentialName, metav1.GetOptions{})
```
Returns an empty `cert` instead of nil even when `err` is set.
This change prevents calling `UpdateCertificate` when Certificate.Get returns error.

**To Reproduce**
Without this change, run `skaffold dev`, apply the following Gateway
```
apiVersion: networking.istio.io/v1beta1
kind: Gateway
metadata:
  labels:
    "v1beta1.kanopy-platform.github.io/istio-cert-controller-inject-simple-credential-name": "true"
  name: httpbin-gateway
  namespace: devops
spec:
  selector:
    istio: ingressgateway
  servers:
    - hosts:
        - devops/httpbin.gateway.example.com
        - devops/httpbin.devops.example.com
      port:
        name: https
        number: 443
        protocol: HTTPS
      tls:
        credentialName: devops-httpbin-gateway-https
        mode: SIMPLE
```

See these logs which show the code is taking the path of `Found certificate` -> `pre-update` -> `error on certificate update`, even though the Certificate does not exist.
Notice on the 3rd log where `"cert":{"name":""}` and is not nil as expected.
```
[kanopy-gateway-cert-controller] {"level":"debug","ts":1655403542.6345387,"msg":"Found certificate","controller":"istio-gateway-controller","object":{"name":"httpbin-gateway","namespace":"devops"},"namespace":"devops","name":"httpbin-gateway","reconcileID":"ea1aa748-0cf4-4fbc-9419-394878c8142b","server":"port:<number:443 protocol:\"HTTPS\" name:\"https\" > hosts:\"devops/httpbin.gateway.example.com\" hosts:\"devops/httpbin.devops.example.com\" tls:<mode:SIMPLE credential_name:\"devops-httpbin-gateway-https\" > "}
[kanopy-gateway-cert-controller] {"level":"debug","ts":1655403542.634945,"msg":"pre-update","controller":"istio-gateway-controller","object":{"name":"httpbin-gateway","namespace":"devops"},"namespace":"devops","name":"httpbin-gateway","reconcileID":"ea1aa748-0cf4-4fbc-9419-394878c8142b","cert":{"name":""}}
[kanopy-gateway-cert-controller] {"level":"error","ts":1655403542.6369967,"msg":"error on certificate update","controller":"istio-gateway-controller","object":{"name":"httpbin-gateway","namespace":"devops"},"namespace":"devops","name":"httpbin-gateway","reconcileID":"ea1aa748-0cf4-4fbc-9419-394878c8142b","cert":{"name":""},"error":"resource name may not be empty","stacktrace":"github.com/kanopy-platform/gateway-certificate-controller/internal/controllers/v1beta1.(*GatewayController).Reconcile\n\tgithub.com/kanopy-platform/gateway-certificate-controller/internal/controllers/v1beta1/gateway.go:134\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\tsigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:121\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\tsigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:320\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\tsigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\tsigs.k8s.io/controller-runtime@v0.12.1/pkg/internal/controller/controller.go:234"}
```