### PR TITLE
Bugfix: Fix example metrics port

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
           ports:
-            - containerPort: 80
+            - containerPort: 8081
               name: metrics
             - containerPort: 8443
               name: webhooks
@@ -81,7 +81,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 80
+    targetPort: 8081
     name: metrics   
   - port: 8443
     targetPort: 8443


### PR DESCRIPTION
https://github.com/kanopy-platform/gateway-certificate-controller/pull/11 changed the default metrics port to be 8081. This updates the examples to match.

**Test**
Bring up minikube
`skaffold dev`
kubectl port-forward -n devops svc/kanopy-gateway-cert-controller 5000:80
Visit `http://localhost:5000/metrics`