### PR TITLE
handling nil TLS configuration in a Gateway

### DIFF
--- a/internal/controllers/v1beta1/garbagecollection/garbagecollection.go
+++ b/internal/controllers/v1beta1/garbagecollection/garbagecollection.go
@@ -131,7 +131,7 @@ func updateFunc(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 
 func isCertificateInGatewaySpec(certificate string, gateway *networkingv1beta1.Gateway) bool {
 	for _, s := range gateway.Spec.Servers {
-		if s.Tls.CredentialName == certificate {
+		if s.Tls != nil && s.Tls.CredentialName == certificate {
 			return true
 		}
 	}

--- a/internal/controllers/v1beta1/garbagecollection/garbagecollection_test.go
+++ b/internal/controllers/v1beta1/garbagecollection/garbagecollection_test.go
@@ -208,6 +208,9 @@ func TestIsCertificateInGatewaySpec(t *testing.T) {
 						CredentialName: "devops-gateway-123-https",
 					},
 				},
+				{
+					Tls: nil,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
It is possible for the user to remove the TLS configuration on a Gateway that is labeled.  This change will allow the certificate to be garbage collected properly if there are no matches due to nil TLS.