### PR TITLE
Bugfix handle nil map on gateways

### DIFF
--- a/internal/admission/admission.go
+++ b/internal/admission/admission.go
@@ -186,6 +186,9 @@ func (edc *ExternalDNSConfig) mutate(ctx context.Context, gateway *v1beta1.Gatew
 
 	// set the target annotation if we have a target or delete it if we don't
 	if edc.target != "" {
+		if gateway.Annotations == nil {
+			gateway.Annotations = map[string]string{}
+		}
 		gateway.Annotations[v1beta1labels.ExternalDNSTargetAnnotationKey] = edc.target
 	} else {
 		delete(gateway.Annotations, v1beta1labels.ExternalDNSTargetAnnotationKey)

--- a/internal/admission/admission_test.go
+++ b/internal/admission/admission_test.go
@@ -66,7 +66,10 @@ func TestGatewayMutationHook(t *testing.T) {
 	ns.Name = "devops"
 	nsl.set(&ns)
 
-	gmh := NewGatewayMutationHook(istiofake.NewSimpleClientset(), nsl)
+	eDNS := NewExternalDNSConfig()
+	eDNS.SetEnabled(true)
+	eDNS.SetTarget("vanity-target")
+	gmh := NewGatewayMutationHook(istiofake.NewSimpleClientset(), nsl, WithExternalDNSConfig(eDNS))
 
 	scheme := runtime.NewScheme()
 	utilruntime.Must(v1beta1.SchemeBuilder.AddToScheme(scheme))


### PR DESCRIPTION
Adds a nil check when setting the external-dns target annotation. 