### PR TITLE
3976 temporary certificate annotation

### DIFF
--- a/internal/controllers/v1beta1/gateway/gateway.go
+++ b/internal/controllers/v1beta1/gateway/gateway.go
@@ -140,16 +140,9 @@ func (c *GatewayController) Reconcile(ctx context.Context, request reconcile.Req
 func (c *GatewayController) CreateCertificate(ctx context.Context, gateway *networkingv1beta1.Gateway, server *v1beta1.Server) error {
 	log := log.FromContext(ctx)
 	issuer := c.clusterIssuer
-	var tcb bool
 
 	if i, ok := gateway.Annotations[v1beta1labels.IssuerAnnotation]; ok {
 		issuer = i
-	}
-
-	if b, ok := gateway.Annotations[v1beta1labels.IssueTemporaryCertificateAnnotation]; ok {
-		if b == "true" {
-			tcb = true
-		}
 	}
 
 	if server.Tls.Mode != v1beta1.ServerTLSSettings_SIMPLE {
@@ -177,7 +170,7 @@ func (c *GatewayController) CreateCertificate(ctx context.Context, gateway *netw
 		},
 	}
 
-	if tcb {
+	if b, ok := gateway.Annotations[v1beta1labels.IssueTemporaryCertificateAnnotation]; ok && b == "true" {
 		cert.ObjectMeta.Annotations[v1certmanager.IssueTemporaryCertificateAnnotation] = "true"
 	}
 

--- a/internal/controllers/v1beta1/gateway/gateway_test.go
+++ b/internal/controllers/v1beta1/gateway/gateway_test.go
@@ -339,7 +339,7 @@ func TestGatewayReconcile_CreatCertificateWithClusterIssuerFromGatewayAnnotation
 	assert.Equal(t, "ClusterIssuer", cert.Spec.IssuerRef.Kind)
 }
 
-func TestGatewayReconcile_CreatCertificateWithTempCertAnnotation(t *testing.T) {
+func TestGatewayReconcile_CreateCertificateWithTempCertAnnotation(t *testing.T) {
 	t.Parallel()
 	helper := NewTestHelperWithGateways(WithAnnotations(map[string]string{
 		v1beta1labels.IssueTemporaryCertificateAnnotation: "true",

--- a/internal/controllers/v1beta1/gateway/gateway_test.go
+++ b/internal/controllers/v1beta1/gateway/gateway_test.go
@@ -339,6 +339,19 @@ func TestGatewayReconcile_CreatCertificateWithClusterIssuerFromGatewayAnnotation
 	assert.Equal(t, "ClusterIssuer", cert.Spec.IssuerRef.Kind)
 }
 
+func TestGatewayReconcile_CreatCertificateWithTempCertAnnotation(t *testing.T) {
+	t.Parallel()
+	helper := NewTestHelperWithGateways(WithAnnotations(map[string]string{
+		v1beta1labels.IssueTemporaryCertificateAnnotation: "true",
+	}))
+	assertCreateCertificateCalled(t, helper)
+	cert, err := helper.CertClient.CertmanagerV1().Certificates(TestCertNamespace).Get(context.TODO(), TestCertificateName, metav1.GetOptions{})
+	assert.NoError(t, err)
+	out, ok := cert.ObjectMeta.Annotations[v1certmanager.IssueTemporaryCertificateAnnotation]
+	assert.True(t, ok)
+	assert.Equal(t, "true", out)
+}
+
 func TestGatewayReconcile_SkipCertificateForTLSModePassthrough(t *testing.T) {
 	t.Parallel()
 	helper := NewTestHelperWithGateways(AppendServer(&networkingv1beta1.Server{

--- a/pkg/v1beta1/labels/labels.go
+++ b/pkg/v1beta1/labels/labels.go
@@ -13,9 +13,10 @@ import (
 type Label string
 
 var (
-	InjectSimpleCredentialNameLabel = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-inject-simple-credential-name")
-	IssuerAnnotation                = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-issuer")
-	ManagedLabel                    = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-managed")
+	InjectSimpleCredentialNameLabel     = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-inject-simple-credential-name")
+	IssuerAnnotation                    = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-issuer")
+	ManagedLabel                        = fmt.Sprintf("%s/%s", version.String(), "istio-cert-controller-managed")
+	IssueTemporaryCertificateAnnotation = fmt.Sprintf("%s/%s", version.String(), IssueTemporaryCertificate)
 )
 
 const (
@@ -25,8 +26,11 @@ const (
 	//ExternalDNSTargetAnnotationKey the external-dns annotation for setting the target of the host record
 	ExternalDNSTargetAnnotationKey = "external-dns.alpha.kubernetes.io/target"
 
-	//IngressAllowListAnnotation the default key for the label controlling external-dns mutation opt out
+	//DefaultGatewayAllowListAnnotation the default key for the label controlling external-dns mutation opt out
 	DefaultGatewayAllowListAnnotation = "ingress-whitelist"
+
+	//IssueTemporaryCertificate idicates that the cert-manager.io/issue-temporary-certificate annotation for a certificate should be set to true
+	IssueTemporaryCertificate = "issue-temporary-certificate"
 
 	//DefaultGatewayAllowListAnnotationOverrideValue the default value for the label controlling external-dns mutation opt out
 	DefaultGatewayAllowListAnnotationOverrideValue = "*"


### PR DESCRIPTION
* Adds support for the namespaced "issue-temporary-certificate"  annotation on Gateways
* Adds a test for the propagation of the annotation to the Certificates "cert-manager.io/issue-temporary-certificate" annotation.

The logic for the controller namespaced "issue-temporary-certificate"  annotation align with the [cert-manager logic](https://cert-manager.io/docs/usage/certificate/#temporary-certificates-whilst-issuing).
