### PR TITLE
4043 lookup cache

### DIFF
--- a/examples/k8s/deployment.yaml
+++ b/examples/k8s/deployment.yaml
@@ -1,8 +1,16 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kanopy-gateway-cert-controller
+  labels:
+    app: kanopy-gateway-cert-controller
+...
+---
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
-  name: kanopy-gateway-cert-controller-selfsigned
+  name: selfsigned-kanopy-gateway-cert-controller
 spec:
   selfSigned: {}
 ---
@@ -16,8 +24,8 @@ spec:
     - kanopy-gateway-cert-controller.routing.svc
     - kanopy-gateway-cert-controller.routing.svc.cluster.local
   issuerRef:
-    name: kanopy-gateway-cert-controller-selfsigned
-  
+    name: selfsigned-kanopy-gateway-cert-controller
+...
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -71,8 +79,8 @@ spec:
         - name: webhook-certs
           secret:
             secretName: kanopy-gateway-cert-controller
-
----   
+...
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -89,15 +97,7 @@ spec:
     name: webhooks
   selector:
     app: kanopy-gateway-cert-controller
-
----   
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kanopy-gateway-cert-controller
-  labels:
-    app: kanopy-gateway-cert-controller
-
+...
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -129,3 +129,4 @@ webhooks:
     resources:
     - gateways
     scope: "Namespaced"
+...

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/cert-manager/cert-manager v1.8.0
+	github.com/go-logr/logr v1.2.3
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
@@ -29,7 +30,6 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/internal/controllers/v1beta1/gateway/options.go
+++ b/internal/controllers/v1beta1/gateway/options.go
@@ -1,5 +1,9 @@
 package gateway
 
+import (
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/cache"
+)
+
 type OptionsFunc func(*GatewayController)
 
 func WithCertificateNamespace(namespace string) OptionsFunc {
@@ -19,5 +23,11 @@ func WithDefaultClusterIssuer(issuer string) OptionsFunc {
 func WithDryRun(dryrun bool) OptionsFunc {
 	return func(gc *GatewayController) {
 		gc.dryRun = dryrun
+	}
+}
+
+func WithGatewayLookupCache(glc *cache.GatewayLookupCache) OptionsFunc {
+	return func(gc *GatewayController) {
+		gc.gatewayLookupCache = glc
 	}
 }

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -11,10 +11,6 @@ import (
 	klog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func main() {
-	fmt.Println("vim-go")
-}
-
 // GatewayLookupCache provides concurrency safe lookups from dns host to namespace/gateway
 // Use New() as the Add, Delete, and Get functions all assume the cache map is non-nil
 type GatewayLookupCache struct {

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -151,13 +151,13 @@ func diffSlices(old, newer []string) ([]string, []string) {
 			}
 		}
 
-		if current[newVal] != true {
+		if !current[newVal] {
 			adds = append(adds, newVal)
 		}
 	}
 
 	for _, oldVal := range old {
-		if current[oldVal] != true {
+		if !current[oldVal] {
 			dels = append(dels, oldVal)
 		}
 	}

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"strings"
 
 	"sync"
 
@@ -117,9 +118,17 @@ func gwToHosts(gw *v1beta1.Gateway) []string {
 
 	for _, server := range gw.Spec.Servers {
 		for _, host := range server.Hosts {
-			if host != "*" {
-				hosts = append(hosts, host)
+			// wildcard certificates cannot be solved via http-01
+			if strings.Contains(host, "*") {
+				continue
 			}
+
+			// split hosts in the namespace/dns.host.name format
+			out, post, ok := strings.Cut(host, "/")
+			if ok {
+				out = post
+			}
+			hosts = append(hosts, out)
 		}
 	}
 

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -1,0 +1,155 @@
+package cache
+
+import (
+	"fmt"
+
+	"sync"
+
+	v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+)
+
+func main() {
+	fmt.Println("vim-go")
+}
+
+// GatewayLookupCache provides concurrency safe lookups from dns host to namespace/gateway
+// Use New() as the Add, Delete, and Get functions all assume the cache map is non-nil
+type GatewayLookupCache struct {
+	cache map[string]string
+	mutex sync.Mutex
+}
+
+func New() *GatewayLookupCache {
+	return &GatewayLookupCache{
+		cache: make(map[string]string),
+		mutex: sync.Mutex{},
+	}
+
+}
+
+func (glc *GatewayLookupCache) Add(gateway string, hosts ...string) {
+	glc.mutex.Lock()
+	defer glc.mutex.Unlock()
+
+	for _, host := range hosts {
+		glc.cache[host] = gateway
+	}
+}
+
+func (glc *GatewayLookupCache) Delete(hosts ...string) {
+	glc.mutex.Lock()
+	defer glc.mutex.Unlock()
+
+	for _, host := range hosts {
+		delete(glc.cache, host)
+	}
+}
+
+func (glc *GatewayLookupCache) Get(host string) (string, bool) {
+	glc.mutex.Lock()
+	defer glc.mutex.Unlock()
+
+	gw, ok := glc.cache[host]
+	return gw, ok
+}
+
+func (glc *GatewayLookupCache) AddFunc(obj interface{}) error {
+	gw, ok := obj.(*v1beta1.Gateway)
+	if !ok {
+		return fmt.Errorf("Not a gateway.v1beta1.istio.io resource")
+
+	}
+
+	if gw == nil {
+		return nil
+	}
+
+	namespacedName := fmt.Sprintf("%s/%s", gw.Namespace, gw.Name)
+	hosts := gwToHosts(gw)
+	glc.Add(namespacedName, hosts...)
+	return nil
+}
+func (glc *GatewayLookupCache) DeleteFunc(obj interface{}) error {
+	gw, ok := obj.(*v1beta1.Gateway)
+	if !ok {
+		return fmt.Errorf("Not a gateway.v1beta1.istio.io resource")
+
+	}
+
+	if gw == nil {
+		return nil
+	}
+
+	hosts := gwToHosts(gw)
+	glc.Delete(hosts...)
+	return nil
+}
+func (glc *GatewayLookupCache) UpdateFunc(oldObj, newObj interface{}) error {
+	oldGW, ok := oldObj.(*v1beta1.Gateway)
+	if !ok {
+		return fmt.Errorf("Old obj not a gateway.v1beta1.istio.io resource")
+
+	}
+
+	newGW, ok := newObj.(*v1beta1.Gateway)
+	if !ok {
+		return fmt.Errorf("New obj not a gateway.v1beta1.istio.io resource")
+
+	}
+
+	if oldGW == nil || newGW == nil {
+		return nil
+	}
+
+	namespacedName := fmt.Sprintf("%s/%s", newGW.Namespace, newGW.Name)
+	adds, deletes := diffSlices(gwToHosts(oldGW), gwToHosts(newGW))
+
+	glc.Add(namespacedName, adds...)
+	glc.Delete(deletes...)
+	return nil
+}
+
+func gwToHosts(gw *v1beta1.Gateway) []string {
+	hosts := []string{}
+	if gw == nil {
+		return hosts
+	}
+
+	for _, server := range gw.Spec.Servers {
+		for _, host := range server.Hosts {
+			if host != "*" {
+				hosts = append(hosts, host)
+			}
+		}
+	}
+
+	return hosts
+}
+
+//diffSlices takes two slices an returns a list of additions and subtractions in the newer list
+func diffSlices(old, newer []string) ([]string, []string) {
+	adds, dels := []string{}, []string{}
+
+	current := map[string]bool{}
+
+	for _, newVal := range newer {
+		for _, oldVal := range old {
+			if oldVal == newVal {
+				current[newVal] = true
+				break
+			}
+		}
+
+		if current[newVal] != true {
+			adds = append(adds, newVal)
+		}
+	}
+
+	for _, oldVal := range old {
+		if current[oldVal] != true {
+			dels = append(dels, oldVal)
+		}
+	}
+
+	return adds, dels
+}

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -70,14 +70,12 @@ func (glc *GatewayLookupCache) AddFunc(obj interface{}) {
 	hosts := gwToHosts(gw)
 	glc.Add(namespacedName, hosts...)
 
-	return
 }
 func (glc *GatewayLookupCache) DeleteFunc(obj interface{}) {
 	gw, ok := obj.(*v1beta1.Gateway)
 	if !ok {
 		glc.logger.V(1).Info("Not a gateway.v1beta1.istio.io resource")
 		return
-
 	}
 
 	if gw == nil {
@@ -86,8 +84,8 @@ func (glc *GatewayLookupCache) DeleteFunc(obj interface{}) {
 
 	hosts := gwToHosts(gw)
 	glc.Delete(hosts...)
-	return
 }
+
 func (glc *GatewayLookupCache) UpdateFunc(oldObj, newObj interface{}) {
 	oldGW, ok := oldObj.(*v1beta1.Gateway)
 	if !ok {
@@ -112,7 +110,6 @@ func (glc *GatewayLookupCache) UpdateFunc(oldObj, newObj interface{}) {
 
 	glc.Add(namespacedName, adds...)
 	glc.Delete(deletes...)
-	return
 }
 
 func gwToHosts(gw *v1beta1.Gateway) []string {

--- a/pkg/v1beta1/cache/cache.go
+++ b/pkg/v1beta1/cache/cache.go
@@ -140,7 +140,7 @@ func gwToHosts(gw *v1beta1.Gateway) []string {
 	return hosts
 }
 
-//diffSlices takes two slices an returns a list of additions and subtractions in the newer list
+// diffSlices takes two slices an returns a list of additions and subtractions in the newer list
 func diffSlices(old, newer []string) ([]string, []string) {
 	adds, dels := []string{}, []string{}
 

--- a/pkg/v1beta1/cache/cache_test.go
+++ b/pkg/v1beta1/cache/cache_test.go
@@ -1,0 +1,238 @@
+package cache_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/cache"
+	"github.com/stretchr/testify/assert"
+
+	networkingv1beta1 "istio.io/api/networking/v1beta1"
+	v1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGatewayLookupCache(t *testing.T) {
+	t.Parallel()
+
+	glc := cache.New()
+
+	tests := []struct {
+		gw         string
+		hosts      []string
+		del        bool
+		getInitial bool
+		getAfter   bool
+		name       string
+	}{
+		{
+			gw: "testNS/testGW",
+			hosts: []string{
+				"a.example.com",
+				"b.example.com",
+			},
+			getAfter: true,
+			name:     "setup",
+		},
+		{
+			gw: "testNS/replacementGateway",
+			hosts: []string{
+				"a.example.com",
+				"b.example.com",
+			},
+			getInitial: true,
+			getAfter:   true,
+			name:       "update",
+		},
+		{
+			gw: "testNS/replacementGateway",
+			hosts: []string{
+				"a.example.com",
+				"b.example.com",
+			},
+			del:        true,
+			name:       "delete",
+			getInitial: true,
+		},
+		{
+			name: "deleted",
+		},
+	}
+
+	for _, test := range tests {
+		out, ok := glc.Get("a.example.com")
+		fmt.Println(out)
+		assert.Equal(t, test.getInitial, ok, test.name+" before")
+		glc.Add(test.gw, test.hosts...)
+		if test.del {
+			glc.Delete(test.hosts...)
+		}
+
+		out, ok = glc.Get("a.example.com")
+
+		assert.Equal(t, test.getAfter, ok, test.name+" after")
+		if ok {
+			assert.Equal(t, test.gw, out, test.name)
+		}
+
+	}
+}
+
+func TestGatewayLookupCacheEventAddFunc(t *testing.T) {
+
+	gw := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testy",
+			Namespace: "example",
+		},
+		Spec: networkingv1beta1.Gateway{
+			Servers: []*networkingv1beta1.Server{
+				&networkingv1beta1.Server{
+					Hosts: []string{
+						"a.b.c.d",
+						"a.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	glc := cache.New()
+
+	assert.NoError(t, glc.AddFunc(gw))
+
+	out, ok := glc.Get("a.b.c.d")
+	assert.Equal(t, "example/testy", out)
+	out, ok = glc.Get("a.example.com")
+	assert.Equal(t, "example/testy", out)
+
+	_, ok = glc.Get("missing")
+	assert.False(t, ok)
+
+	gw = &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing",
+			Namespace: "example",
+		},
+		Spec: networkingv1beta1.Gateway{
+			Servers: []*networkingv1beta1.Server{
+				&networkingv1beta1.Server{
+					Hosts: []string{
+						"missing",
+					},
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, glc.AddFunc(gw))
+	out, ok = glc.Get("missing")
+	assert.True(t, ok)
+	assert.Equal(t, "example/missing", out)
+}
+
+func TestGatewayLookupCacheEventUpdateFunc(t *testing.T) {
+	original := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testy",
+			Namespace: "example",
+		},
+		Spec: networkingv1beta1.Gateway{
+			Servers: []*networkingv1beta1.Server{
+				&networkingv1beta1.Server{
+					Hosts: []string{
+						"a.b.c.d",
+						"a.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	updated := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testy",
+			Namespace: "example",
+		},
+		Spec: networkingv1beta1.Gateway{
+			Servers: []*networkingv1beta1.Server{
+				&networkingv1beta1.Server{
+					Hosts: []string{
+						"a.b.c.d",
+						"b.example.com",
+						"x.y.z",
+					},
+				},
+			},
+		},
+	}
+
+	glc := cache.New()
+
+	assert.NoError(t, glc.AddFunc(original))
+
+	_, ok := glc.Get("a.example.com")
+	assert.True(t, ok)
+
+	assert.NoError(t, glc.UpdateFunc(original, updated))
+	_, ok = glc.Get("a.example.com")
+	assert.False(t, ok)
+	for _, host := range updated.Spec.Servers[0].Hosts {
+
+		out, ok := glc.Get(host)
+		assert.True(t, ok)
+		assert.Equal(t, fmt.Sprintf("%s/%s", updated.Namespace, updated.Name), out)
+	}
+
+}
+func TestGatewayLookupCacheEventDeleteFunc(t *testing.T) {
+	gw := &v1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testy",
+			Namespace: "example",
+		},
+		Spec: networkingv1beta1.Gateway{
+			Servers: []*networkingv1beta1.Server{
+				&networkingv1beta1.Server{
+					Hosts: []string{
+						"a.b.c.d",
+						"a.example.com",
+					},
+				},
+			},
+		},
+	}
+
+	glc := cache.New()
+
+	assert.NoError(t, glc.AddFunc(gw))
+	_, ok := glc.Get("a.example.com")
+	assert.True(t, ok)
+
+	assert.NoError(t, glc.DeleteFunc(gw))
+	for _, host := range gw.Spec.Servers[0].Hosts {
+
+		_, ok := glc.Get(host)
+		assert.False(t, ok)
+	}
+
+}
+
+func TestGatewayLookupCacheEventFuncErrors(t *testing.T) {
+
+	thing := "notagatewaypointer"
+	gw := &v1beta1.Gateway{}
+	glc := cache.New()
+	// Ensure that an error is returned if the input isn't a *Gateway
+	assert.Error(t, glc.AddFunc(thing))
+	assert.Error(t, glc.UpdateFunc(thing, gw))
+	assert.Error(t, glc.UpdateFunc(gw, thing))
+	assert.Error(t, glc.DeleteFunc(thing))
+
+	// Ensure no error is returned for a nil gateway, a nil gateway results in no changes
+	var ngw *v1beta1.Gateway
+	assert.NoError(t, glc.AddFunc(ngw))
+	assert.NoError(t, glc.UpdateFunc(gw, ngw))
+	assert.NoError(t, glc.UpdateFunc(ngw, gw))
+	assert.NoError(t, glc.DeleteFunc(ngw))
+}

--- a/pkg/v1beta1/cache/cache_test.go
+++ b/pkg/v1beta1/cache/cache_test.go
@@ -99,8 +99,7 @@ func TestGatewayLookupCacheEventAddFunc(t *testing.T) {
 	}
 
 	glc := cache.New()
-
-	assert.NoError(t, glc.AddFunc(gw))
+	glc.AddFunc(gw)
 
 	out, _ := glc.Get("a.b.c.d")
 	assert.Equal(t, "example/testy", out)
@@ -130,7 +129,7 @@ func TestGatewayLookupCacheEventAddFunc(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, glc.AddFunc(gw))
+	glc.AddFunc(gw)
 	out, ok = glc.Get("missing")
 	assert.True(t, ok)
 	assert.Equal(t, "example/missing", out)
@@ -173,13 +172,12 @@ func TestGatewayLookupCacheEventUpdateFunc(t *testing.T) {
 	}
 
 	glc := cache.New()
-
-	assert.NoError(t, glc.AddFunc(original))
+	glc.AddFunc(original)
 
 	_, ok := glc.Get("a.example.com")
 	assert.True(t, ok)
 
-	assert.NoError(t, glc.UpdateFunc(original, updated))
+	glc.UpdateFunc(original, updated)
 	_, ok = glc.Get("a.example.com")
 	assert.False(t, ok)
 	for _, host := range updated.Spec.Servers[0].Hosts {
@@ -210,11 +208,11 @@ func TestGatewayLookupCacheEventDeleteFunc(t *testing.T) {
 
 	glc := cache.New()
 
-	assert.NoError(t, glc.AddFunc(gw))
+	glc.AddFunc(gw)
 	_, ok := glc.Get("a.example.com")
 	assert.True(t, ok)
 
-	assert.NoError(t, glc.DeleteFunc(gw))
+	glc.DeleteFunc(gw)
 	for _, host := range gw.Spec.Servers[0].Hosts {
 
 		_, ok := glc.Get(host)
@@ -223,21 +221,21 @@ func TestGatewayLookupCacheEventDeleteFunc(t *testing.T) {
 
 }
 
-func TestGatewayLookupCacheEventFuncErrors(t *testing.T) {
+func TestGatewayLookupCacheEventFuncEdgeCases(t *testing.T) {
 
 	thing := "notagatewaypointer"
 	gw := &v1beta1.Gateway{}
 	glc := cache.New()
 	// Ensure that an error is returned if the input isn't a *Gateway
-	assert.Error(t, glc.AddFunc(thing))
-	assert.Error(t, glc.UpdateFunc(thing, gw))
-	assert.Error(t, glc.UpdateFunc(gw, thing))
-	assert.Error(t, glc.DeleteFunc(thing))
+	assert.NotPanics(t, func() { glc.AddFunc(thing) })
+	assert.NotPanics(t, func() { glc.UpdateFunc(thing, gw) })
+	assert.NotPanics(t, func() { glc.UpdateFunc(gw, thing) })
+	assert.NotPanics(t, func() { glc.DeleteFunc(thing) })
 
 	// Ensure no error is returned for a nil gateway, a nil gateway results in no changes
 	var ngw *v1beta1.Gateway
-	assert.NoError(t, glc.AddFunc(ngw))
-	assert.NoError(t, glc.UpdateFunc(gw, ngw))
-	assert.NoError(t, glc.UpdateFunc(ngw, gw))
-	assert.NoError(t, glc.DeleteFunc(ngw))
+	assert.NotPanics(t, func() { glc.AddFunc(ngw) })
+	assert.NotPanics(t, func() { glc.UpdateFunc(gw, ngw) })
+	assert.NotPanics(t, func() { glc.UpdateFunc(ngw, gw) })
+	assert.NotPanics(t, func() { glc.DeleteFunc(ngw) })
 }

--- a/pkg/v1beta1/cache/cache_test.go
+++ b/pkg/v1beta1/cache/cache_test.go
@@ -61,7 +61,6 @@ func TestGatewayLookupCache(t *testing.T) {
 
 	for _, test := range tests {
 		out, ok := glc.Get("a.example.com")
-		fmt.Println(out)
 		assert.Equal(t, test.getInitial, ok, test.name+" before")
 		glc.Add(test.gw, test.hosts...)
 		if test.del {
@@ -91,6 +90,8 @@ func TestGatewayLookupCacheEventAddFunc(t *testing.T) {
 					Hosts: []string{
 						"a.b.c.d",
 						"a.example.com",
+						"example/dns.host.name",
+						"*.dns.example.com",
 					},
 				},
 			},
@@ -101,12 +102,16 @@ func TestGatewayLookupCacheEventAddFunc(t *testing.T) {
 
 	assert.NoError(t, glc.AddFunc(gw))
 
-	out, ok := glc.Get("a.b.c.d")
+	out, _ := glc.Get("a.b.c.d")
 	assert.Equal(t, "example/testy", out)
-	out, ok = glc.Get("a.example.com")
+	out, _ = glc.Get("a.example.com")
+	assert.Equal(t, "example/testy", out)
+	out, _ = glc.Get("dns.host.name")
 	assert.Equal(t, "example/testy", out)
 
-	_, ok = glc.Get("missing")
+	_, ok := glc.Get("missing")
+	assert.False(t, ok)
+	_, ok = glc.Get("*.dns.example.com")
 	assert.False(t, ok)
 
 	gw = &v1beta1.Gateway{

--- a/pkg/v1beta1/cache/cache_test.go
+++ b/pkg/v1beta1/cache/cache_test.go
@@ -60,14 +60,14 @@ func TestGatewayLookupCache(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		out, ok := glc.Get("a.example.com")
+		_, ok := glc.Get("a.example.com")
 		assert.Equal(t, test.getInitial, ok, test.name+" before")
 		glc.Add(test.gw, test.hosts...)
 		if test.del {
 			glc.Delete(test.hosts...)
 		}
 
-		out, ok = glc.Get("a.example.com")
+		out, ok := glc.Get("a.example.com")
 
 		assert.Equal(t, test.getAfter, ok, test.name+" after")
 		if ok {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,13 +4,16 @@ kind: Config
 build:
   insecureRegistries:
     - registry.example.com
-  local:
-    push: true
+  tagPolicy:
+    gitCommit: {}
   artifacts:
     - image: registry.example.com/kanopy-gateway-cert-controller
-      ko: {}
+      kaniko:
+        skipTLS: true
+        buildArgs:
+  cluster: {}
 deploy:
-  kubeContext: minikube
+  kubeContext: kind-kind
   kubectl:
     defaultNamespace: routing
     manifests:


### PR DESCRIPTION
This adds a dns hostname to namespace/gateway name lookup cache that is populated by the gateway informers. It will be consumed by the challenge solvers to identify which gateway should be used for the VirtualService that will  route requests to the http-01 solver service created by cert-manager http-01 solver.

The gateway provides blocking mutex locks for Add, Delete, and Get operations to make it safe for use between multiple controllers.

The GLC will be shared between the gateway controller and the to be implemented challenge controller. 

Unit tests are inline with the cache module.