### PR TITLE
VirtualService Challenge Solver

### DIFF
--- a/pkg/v1beta1/challengesolver/solver.go
+++ b/pkg/v1beta1/challengesolver/solver.go
@@ -94,7 +94,7 @@ func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challeng
 		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", acmev1.DomainLabelKey, httpDomainHash, acmev1.TokenLabelKey, tokenHash),
 	}
 
-	serviceList, err := cs.coreClient.Services(challenge.Namespace).List(context.TODO(), listOpts)
+	serviceList, err := cs.coreClient.Services(challenge.Namespace).List(ctx, listOpts)
 	if err != nil {
 		// requeue the request to wait for the service to appear in the api
 		return nil, err
@@ -124,7 +124,7 @@ func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challeng
 	vsApply := VirtualServiceApplyFromChallengeMeta(cm)
 
 	// This controller is authoritative for these virtualservices so stomp any old versions that exist
-	return cs.networkingClient.VirtualServices(challenge.Namespace).Apply(context.TODO(), vsApply, metav1.ApplyOptions{Force: true})
+	return cs.networkingClient.VirtualServices(challenge.Namespace).Apply(ctx, vsApply, metav1.ApplyOptions{Force: true})
 }
 
 func (cs *ChallengeSolver) Hash(in string) string {

--- a/pkg/v1beta1/challengesolver/solver.go
+++ b/pkg/v1beta1/challengesolver/solver.go
@@ -1,0 +1,191 @@
+package challengesolver
+
+import (
+	"context"
+	"fmt"
+	"hash/adler32"
+
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	acmev1Client "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/acme/v1"
+
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/cache"
+
+	apinetv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	netapplymetav1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
+	netapplyv1beta1 "istio.io/client-go/pkg/applyconfiguration/networking/v1beta1"
+	networkingv1beta1Client "istio.io/client-go/pkg/clientset/versioned/typed/networking/v1beta1"
+
+	istiov1beta1 "istio.io/api/networking/v1beta1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type ChallengeSolver struct {
+	coreClient       corev1.CoreV1Interface
+	networkingClient networkingv1beta1Client.NetworkingV1beta1Interface
+	acmeClient       acmev1Client.AcmeV1Interface
+	glc              *cache.GatewayLookupCache
+}
+
+func NewChallengeSolver(cc corev1.CoreV1Interface, nc networkingv1beta1Client.NetworkingV1beta1Interface, ac acmev1Client.AcmeV1Interface, glc *cache.GatewayLookupCache) *ChallengeSolver {
+	return &ChallengeSolver{
+		coreClient:       cc,
+		networkingClient: nc,
+		acmeClient:       ac,
+		glc:              glc,
+	}
+}
+
+func (cs *ChallengeSolver) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+
+	log := log.FromContext(ctx)
+	log.Info("Reconciling Acme Challenge", "reconcile", req.String())
+	log.V(1).Info("Debug")
+
+	challenge, err := cs.acmeClient.Challenges(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			//for a reconciler this likely means deletion, owner references will clean up any existing VirtualServices
+			return reconcile.Result{}, nil
+		}
+
+		log.Error(err, "Error reconciling challenge, requeued")
+		return reconcile.Result{
+			Requeue: true,
+		}, err
+	}
+
+	_, err = cs.Solve(ctx, challenge)
+	if err != nil {
+		//TODO type errors as recoverable or not
+		return reconcile.Result{
+			Requeue: true,
+		}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challenge) (*apinetv1beta1.VirtualService, error) {
+	log := log.FromContext(ctx)
+	log.V(1).Info("Debug")
+
+	if challenge == nil {
+		return nil, nil
+	}
+
+	httpDomainHash := cs.Hash(challenge.Spec.DNSName)
+	tokenHash := cs.Hash(challenge.Spec.Token)
+
+	namespacedGateway, ok := cs.glc.Get(challenge.Spec.DNSName)
+	if !ok {
+		// requeue the request to wait for the lookup cache to populate
+		// probably needs backoff
+		return nil, fmt.Errorf("Host %s: Gateway not found.", challenge.Spec.DNSName)
+	}
+	log.V(1).Info(fmt.Sprintf("Debug: gateway found %s", namespacedGateway))
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", acmev1.DomainLabelKey, httpDomainHash, acmev1.TokenLabelKey, tokenHash),
+	}
+
+	serviceList, err := cs.coreClient.Services(challenge.Namespace).List(context.TODO(), listOpts)
+	if err != nil {
+		// requeue the request to wait for the service to appear in the api
+		return nil, err
+	}
+
+	if len(serviceList.Items) == 0 {
+		// requeue the request to wait for the service to appear in the api
+		return nil, fmt.Errorf("No service matched selector: %s", fmt.Sprintf("%s=%s,%s=%s", acmev1.DomainLabelKey, httpDomainHash, acmev1.TokenLabelKey, tokenHash))
+	}
+	svc := serviceList.Items[0]
+
+	if len(svc.Spec.Ports) == 0 {
+		// this is probably unrecoverable
+		return nil, fmt.Errorf("Service: %s, missing port definition", svc.Name)
+	}
+
+	cm := ChallengeMeta{
+		Port:      svc.Spec.Ports[0].Port,
+		Service:   svc.Name,
+		DNSName:   challenge.Spec.DNSName,
+		Namespace: challenge.Namespace,
+		Token:     challenge.Spec.Token,
+		Name:      challenge.Name,
+		UID:       challenge.UID,
+		Gateway:   namespacedGateway,
+	}
+	vsApply := VirtualServiceApplyFromChallengeMeta(cm)
+
+	// This controller is authoritative for these virtualservices so stomp any old versions that exist
+	return cs.networkingClient.VirtualServices(challenge.Namespace).Apply(context.TODO(), vsApply, metav1.ApplyOptions{Force: true})
+}
+
+func (cs *ChallengeSolver) Hash(in string) string {
+	return fmt.Sprintf("%d", adler32.Checksum([]byte(in)))
+}
+
+type ChallengeMeta struct {
+	Port      int32
+	Service   string
+	DNSName   string
+	Namespace string
+	Token     string
+	Name      string
+	UID       types.UID
+	Gateway   string
+}
+
+func VirtualServiceApplyFromChallengeMeta(cm ChallengeMeta) *netapplyv1beta1.VirtualServiceApplyConfiguration {
+
+	vsApply := netapplyv1beta1.VirtualServiceApplyConfiguration{
+		ObjectMetaApplyConfiguration: &netapplymetav1.ObjectMetaApplyConfiguration{},
+		Spec: &istiov1beta1.VirtualService{
+			Hosts:    []string{cm.DNSName},
+			Gateways: []string{cm.Gateway},
+			Http: []*istiov1beta1.HTTPRoute{
+				{
+					Name: "solver",
+					Match: []*istiov1beta1.HTTPMatchRequest{
+						{
+							Uri: &istiov1beta1.StringMatch{
+								MatchType: &istiov1beta1.StringMatch_Exact{
+									Exact: fmt.Sprintf("/.well-known/acme-challenge/%s", cm.Token),
+								},
+							},
+						},
+					},
+					Route: []*istiov1beta1.HTTPRouteDestination{
+						{
+							Destination: &istiov1beta1.Destination{
+								Host: cm.Service,
+								Port: &istiov1beta1.PortSelector{
+									Number: uint32(cm.Port),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	apiVersion := acmev1.SchemeGroupVersion.String()
+	kind := "Challenge"
+	vsApply.Namespace = &cm.Namespace
+	vsApply.Name = &cm.Name
+	vsApply.OwnerReferences = append(vsApply.OwnerReferences, netapplymetav1.OwnerReferenceApplyConfiguration{
+		APIVersion: &apiVersion,
+		Kind:       &kind,
+		Name:       &cm.Name,
+		UID:        &cm.UID,
+	})
+
+	return &vsApply
+}

--- a/pkg/v1beta1/challengesolver/solver_test.go
+++ b/pkg/v1beta1/challengesolver/solver_test.go
@@ -1,0 +1,210 @@
+package challengesolver_test
+
+import (
+	"context"
+	"fmt"
+	"hash/adler32"
+	"testing"
+
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/cache"
+	"github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/challengesolver"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/stretchr/testify/assert"
+
+	certmanagerfake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	acmefake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/acme/v1/fake"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	networkingv1beta1fake "istio.io/client-go/pkg/clientset/versioned/typed/networking/v1beta1/fake"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	corev1fake "k8s.io/client-go/kubernetes/typed/core/v1/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestStub(t *testing.T) {
+	t.Parallel()
+
+	glc := cache.New()
+
+	assert.NotNil(t, glc)
+}
+
+type testHelper struct {
+	ics *istiofake.Clientset
+	ccs *certmanagerfake.Clientset
+	scs *k8sfake.Clientset
+	glc *cache.GatewayLookupCache
+}
+
+func (th *testHelper) newTestSolver() *challengesolver.ChallengeSolver {
+	return challengesolver.NewChallengeSolver(th.scs.CoreV1(), th.ics.NetworkingV1beta1(), th.ccs.AcmeV1(), th.glc)
+}
+
+func TestChallengeSolver(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		challenge      *acmev1.Challenge
+		service        corev1.Service
+		virtualService *networkingv1beta1.VirtualService
+		gatewayName    string
+		pass           bool
+		validateVS     bool
+		noRequeue      bool
+	}{
+		{
+			name:      "no challenge",
+			pass:      true,
+			noRequeue: true,
+		},
+		{
+			name:      "No Gateway",
+			challenge: getChallenge("noservice", "example", "noservice.com"),
+			pass:      false,
+		},
+		{
+			name:      "No Gateway",
+			challenge: getChallenge("noservice", "example", "noservice.com"),
+			pass:      false,
+		},
+		{
+			name:        "No Service",
+			challenge:   getChallenge("noservice", "example", "noservice.com"),
+			gatewayName: "gateway",
+			pass:        false,
+		},
+		{
+			name:        "No Service Port",
+			challenge:   getChallenge("noservice", "example", "noservice.com"),
+			gatewayName: "gateway",
+			service:     getService("noportservice", "example", "noportservice.com", 0),
+			pass:        false,
+		},
+		{
+			name:        "Service",
+			challenge:   getChallenge("noservice", "example", "service.com"),
+			gatewayName: "gateway",
+			service:     getService("service", "example", "service.com", 8888),
+			pass:        true,
+			validateVS:  true,
+			noRequeue:   true,
+		},
+	} {
+		th := testHelper{
+			ics: istiofake.NewSimpleClientset(),
+			ccs: certmanagerfake.NewSimpleClientset(),
+			scs: k8sfake.NewSimpleClientset(),
+			glc: cache.New(),
+		}
+
+		if test.service.Name != "" {
+			th.scs.CoreV1().(*corev1fake.FakeCoreV1).PrependReactor(
+				"list",
+				"services",
+				listServiceFunc(test.service))
+		}
+
+		th.ccs.AcmeV1().(*acmefake.FakeAcmeV1).PrependReactor(
+			"get",
+			"challenges",
+			getChallengeFunc(test.challenge))
+
+		if test.challenge != nil {
+
+			if test.gatewayName != "" {
+				th.glc.Add(fmt.Sprintf("%s/%s", test.challenge.Namespace, test.gatewayName), test.challenge.Spec.DNSName)
+			}
+
+			vs := networkingv1beta1.VirtualService{}
+			vs.Name = test.challenge.Name
+			vs.Namespace = test.challenge.Namespace
+			th.ics.NetworkingV1beta1().(*networkingv1beta1fake.FakeNetworkingV1beta1).PrependReactor(
+				"patch",
+				"virtualservices",
+				func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true,
+						&vs,
+						nil
+				})
+
+		}
+
+		cs := th.newTestSolver()
+
+		out, err := cs.Solve(context.Background(), test.challenge)
+
+		if test.pass {
+			assert.NoError(t, err, test.name)
+
+			if test.validateVS {
+				assert.NotNil(t, out, test.name)
+			} else {
+				assert.Nil(t, out, test.name)
+			}
+		} else {
+			assert.Error(t, err, test.name)
+			assert.Nil(t, out, test.name)
+
+		}
+
+		if test.challenge != nil {
+			resp, err := cs.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: test.challenge.Namespace, Name: test.challenge.Name}})
+			if test.pass {
+				assert.NoError(t, err, test.name)
+			}
+
+			if test.noRequeue {
+				assert.False(t, resp.Requeue, test.name)
+			}
+		}
+
+	}
+}
+
+func getChallenge(name, namespace, dnsName string) *acmev1.Challenge {
+	return &acmev1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       "12345",
+		},
+		Spec: acmev1.ChallengeSpec{
+			Token:   "token",
+			DNSName: dnsName,
+		},
+	}
+}
+
+func getChallengeFunc(c *acmev1.Challenge) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, c, nil
+	}
+}
+
+func getService(name, namespace, dnsName string, port int) corev1.Service {
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"acme.cert-manager.io/http-domain": fmt.Sprint(adler32.Checksum([]byte(dnsName))),
+				"acme.cert-manager.io/http-token":  fmt.Sprint(adler32.Checksum([]byte("token"))),
+			},
+		},
+	}
+	if port != 0 {
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{Port: int32(port)})
+	}
+	return svc
+}
+
+func listServiceFunc(services ...corev1.Service) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &corev1.ServiceList{Items: services}, nil
+	}
+}

--- a/pkg/v1beta1/challengesolver/solver_test.go
+++ b/pkg/v1beta1/challengesolver/solver_test.go
@@ -87,7 +87,7 @@ func TestChallengeSolver(t *testing.T) {
 		},
 		{
 			name:        "Service",
-			challenge:   getChallenge("noservice", "example", "service.com"),
+			challenge:   getChallenge("service", "example", "service.com"),
 			gatewayName: "gateway",
 			service:     getService("service", "example", "service.com", 8888),
 			pass:        true,
@@ -160,6 +160,9 @@ func TestChallengeSolver(t *testing.T) {
 
 			if test.noRequeue {
 				assert.False(t, resp.Requeue, test.name)
+			}
+			else {
+				assert.True(t, resp.Requeue, test.name)
 			}
 		}
 

--- a/pkg/v1beta1/challengesolver/solver_test.go
+++ b/pkg/v1beta1/challengesolver/solver_test.go
@@ -160,8 +160,7 @@ func TestChallengeSolver(t *testing.T) {
 
 			if test.noRequeue {
 				assert.False(t, resp.Requeue, test.name)
-			}
-			else {
+			} else {
 				assert.True(t, resp.Requeue, test.name)
 			}
 		}


### PR DESCRIPTION
This adds a challengesolver package that implements the Reconciler interface and can solve an acme challenge from an Acme v1 Challenge resource provided an up to date gateway lookup cache. 

Unit tests are inline. It isn't wired into controller cli or controller manager yet. 
