### PR TITLE
Bugfix Cert solver label flapping

### DIFF
--- a/internal/controllers/v1beta1/gateway/gateway.go
+++ b/internal/controllers/v1beta1/gateway/gateway.go
@@ -250,6 +250,8 @@ func updateHTTPSolver(ctx context.Context, cert *v1certmanager.Certificate, gate
 			log.V(1).Info("Adding http solver label to cert")
 			cert.Labels[label] = "true"
 			return cert, true
+		} else {
+			return cert, false
 		}
 	}
 


### PR DESCRIPTION
This solves a logic bug that caused the controller to continually add and remove the http01 solver label if the gateway had the annotation set to true. 

Unit testing has been added to ensure that the updateHTTPSolver function is idempotent. 