### PR TITLE
Bugfix: skip servers without a TLS config during reconcile

### DIFF
--- a/internal/controllers/v1beta1/gateway/gateway.go
+++ b/internal/controllers/v1beta1/gateway/gateway.go
@@ -132,6 +132,11 @@ func (c *GatewayController) Reconcile(ctx context.Context, request reconcile.Req
 	for _, s := range gateway.Spec.Servers {
 		log.V(1).Info("Inspecting server", "hosts", s.Hosts)
 
+		// skip servers without a TLS config
+		if s.Tls == nil {
+			continue
+		}
+
 		cert, err := c.certClient.CertmanagerV1().Certificates(c.certificateNamespace).Get(ctx, s.Tls.CredentialName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {


### PR DESCRIPTION
Found a small bug when the controller processes gateway servers that don't have a TLS configuration.

In `test`, there is currently a gateway (`login`) that defines both a `HTTP` and `HTTPS` server. Only the HTTPS server has a TLS field, causing a panic during reconcile when processing both servers.

Skipping non-TLS servers is the intended behaviour of this controller. It only manages TLS certificates, so it should process only servers that have a TLS configuration.