### PR TITLE
feat: fallback ingress support

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kanopy-platform/gateway-certificate-controller/internal/admission"
 	v1beta1gc "github.com/kanopy-platform/gateway-certificate-controller/internal/controllers/v1beta1/garbagecollection"
 	v1beta1controllers "github.com/kanopy-platform/gateway-certificate-controller/internal/controllers/v1beta1/gateway"
+	v1beta1orderwatcher "github.com/kanopy-platform/gateway-certificate-controller/internal/controllers/v1beta1/orderwatcher"
 	logzap "github.com/kanopy-platform/gateway-certificate-controller/internal/log/zap"
 
 	"github.com/spf13/cobra"
@@ -84,6 +85,10 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().Bool("enable-fallback-ingress", false, "Enable fallback ingress creation for gateways where DNS is not pointing to Istio")
 	cmd.PersistentFlags().String("dns-disabled-annotation", "", "Annotation key indicating DNS is not pointing to Istio (required if enable-fallback-ingress is true)")
 	cmd.PersistentFlags().String("fallback-ingress-class", "", "IngressClass name for fallback ingress (required if enable-fallback-ingress is true)")
+
+	// Event configuration for order watcher
+	cmd.PersistentFlags().String("cert-ready-event-reason", "CertificateReady", "Event reason emitted when certificate is successfully issued")
+	cmd.PersistentFlags().String("cert-failed-event-reason", "ChallengeFailed", "Event reason emitted when certificate challenge fails")
 
 	k8sFlags.AddFlags(cmd.PersistentFlags())
 	// no need to check err, this only checks if variadic args != 0
@@ -267,6 +272,24 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		)
 
 		err = cs.SetupWithManager(ctx, mgr)
+		if err != nil {
+			return err
+		}
+
+		eventCfg := v1beta1orderwatcher.EventConfig{
+			CertificateReadyReason:  viper.GetString("cert-ready-event-reason"),
+			CertificateFailedReason: viper.GetString("cert-failed-event-reason"),
+		}
+
+		ow := v1beta1orderwatcher.NewOrderWatcher(
+			cmc,
+			ic,
+			mgr.GetEventRecorderFor("gateway-certificate-controller"),
+			v1beta1orderwatcher.WithDryRun(dryRun),
+			v1beta1orderwatcher.WithEventConfig(eventCfg),
+		)
+
+		err = ow.SetupWithManager(ctx, mgr)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagerversionedclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
 	networkingv1 "istio.io/client-go/pkg/apis/networking/v1"
@@ -46,6 +47,7 @@ func init() {
 	utilruntime.Must(networkingv1beta1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(networkingv1.SchemeBuilder.AddToScheme(scheme))
 	utilruntime.Must(certmanagerv1.SchemeBuilder.AddToScheme(scheme))
+	utilruntime.Must(acmev1.SchemeBuilder.AddToScheme(scheme))
 }
 
 // RootCommand is the origin of all command life
@@ -77,6 +79,11 @@ func NewRootCommand() *cobra.Command {
 	cmd.PersistentFlags().String("certificate-namespace", "cert-manager", "Namespace that stores Certificates")
 	cmd.PersistentFlags().String("default-issuer", "selfsigned", "The default ClusterIssuer")
 	cmd.PersistentFlags().String("http-solver-label", "use-istio-http01-solver", "The cert-manager http01 solver selector label to apply to Certificates")
+
+	// Fallback ingress flags for migration scenarios where DNS is not yet pointing to Istio
+	cmd.PersistentFlags().Bool("enable-fallback-ingress", false, "Enable fallback ingress creation for gateways where DNS is not pointing to Istio")
+	cmd.PersistentFlags().String("dns-disabled-annotation", "", "Annotation key indicating DNS is not pointing to Istio (required if enable-fallback-ingress is true)")
+	cmd.PersistentFlags().String("fallback-ingress-class", "", "IngressClass name for fallback ingress (required if enable-fallback-ingress is true)")
 
 	k8sFlags.AddFlags(cmd.PersistentFlags())
 	// no need to check err, this only checks if variadic args != 0
@@ -233,7 +240,31 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	serviceLister := coreV1Informer.Services().Lister()
 
 	if viper.GetBool("challenge-solver") {
-		cs := challengesolver.NewChallengeSolver(serviceLister, ic.NetworkingV1beta1(), cmc, glc, challengesolver.WithDryRun(dryRun))
+		fallbackCfg := challengesolver.FallbackIngressConfig{
+			Enabled:               viper.GetBool("enable-fallback-ingress"),
+			DNSDisabledAnnotation: viper.GetString("dns-disabled-annotation"),
+			IngressClass:          viper.GetString("fallback-ingress-class"),
+		}
+
+		if fallbackCfg.Enabled {
+			if fallbackCfg.DNSDisabledAnnotation == "" {
+				return fmt.Errorf("--dns-disabled-annotation is required when --enable-fallback-ingress is true")
+			}
+			if fallbackCfg.IngressClass == "" {
+				return fmt.Errorf("--fallback-ingress-class is required when --enable-fallback-ingress is true")
+			}
+			klog.Log.Info("fallback ingress enabled", "annotation", fallbackCfg.DNSDisabledAnnotation, "ingressClass", fallbackCfg.IngressClass)
+		}
+
+		cs := challengesolver.NewChallengeSolver(
+			serviceLister,
+			ic,
+			cmc,
+			clientset,
+			glc,
+			challengesolver.WithDryRun(dryRun),
+			challengesolver.WithFallbackIngress(fallbackCfg),
+		)
 
 		err = cs.SetupWithManager(ctx, mgr)
 		if err != nil {

--- a/internal/controllers/v1beta1/orderwatcher/options.go
+++ b/internal/controllers/v1beta1/orderwatcher/options.go
@@ -1,0 +1,26 @@
+package orderwatcher
+
+type OptionsFunc func(*OrderWatcher)
+
+func WithDryRun(dryrun bool) OptionsFunc {
+	return func(ow *OrderWatcher) {
+		ow.dryRun = dryrun
+	}
+}
+
+// EventConfig holds the configurable event reason strings.
+type EventConfig struct {
+	CertificateReadyReason  string
+	CertificateFailedReason string
+}
+
+func WithEventConfig(cfg EventConfig) OptionsFunc {
+	return func(ow *OrderWatcher) {
+		if cfg.CertificateReadyReason != "" {
+			ow.eventConfig.CertificateReadyReason = cfg.CertificateReadyReason
+		}
+		if cfg.CertificateFailedReason != "" {
+			ow.eventConfig.CertificateFailedReason = cfg.CertificateFailedReason
+		}
+	}
+}

--- a/internal/controllers/v1beta1/orderwatcher/orderwatcher.go
+++ b/internal/controllers/v1beta1/orderwatcher/orderwatcher.go
@@ -1,0 +1,201 @@
+package orderwatcher
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certmanagerversionedclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	certmanagerinformers "github.com/cert-manager/cert-manager/pkg/client/informers/externalversions"
+
+	v1beta1labels "github.com/kanopy-platform/gateway-certificate-controller/pkg/v1beta1/labels"
+
+	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// OrderWatcher watches cert-manager Order resources and emits Kubernetes events
+// on the associated Gateway when certificates are successfully issued or fail.
+type OrderWatcher struct {
+	certmanagerClient certmanagerversionedclient.Interface
+	istioClient       istioversionedclient.Interface
+	recorder          record.EventRecorder
+	dryRun            bool
+	eventConfig       EventConfig
+
+	// processedOrders tracks which orders we've already emitted events for
+	// to avoid duplicate events on requeue.
+	processedOrders map[string]acmev1.State
+}
+
+func NewOrderWatcher(cmc certmanagerversionedclient.Interface, ic istioversionedclient.Interface, recorder record.EventRecorder, opts ...OptionsFunc) *OrderWatcher {
+	ow := &OrderWatcher{
+		certmanagerClient: cmc,
+		istioClient:       ic,
+		recorder:          recorder,
+		processedOrders:   make(map[string]acmev1.State),
+		eventConfig: EventConfig{
+			CertificateReadyReason:  "CertificateReady",
+			CertificateFailedReason: "ChallengeFailed",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(ow)
+	}
+
+	return ow
+}
+
+func (ow *OrderWatcher) SetupWithManager(ctx context.Context, mgr manager.Manager) error {
+	log := log.FromContext(ctx)
+	log.Info("Registering OrderWatcher controller with Manager")
+
+	ctrl, err := controller.New("orderwatcher", mgr, controller.Options{
+		Reconciler:  ow,
+		RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](time.Second, 1000*time.Second),
+	})
+	if err != nil {
+		return err
+	}
+
+	certmanagerInformerFactory := certmanagerinformers.NewSharedInformerFactoryWithOptions(ow.certmanagerClient, time.Second*30)
+	if err := ctrl.Watch(&source.Informer{
+		Informer: certmanagerInformerFactory.Acme().V1().Orders().Informer(),
+		Handler:  &handler.EnqueueRequestForObject{},
+	}); err != nil {
+		return err
+	}
+
+	certmanagerInformerFactory.Start(wait.NeverStop)
+	certmanagerInformerFactory.WaitForCacheSync(wait.NeverStop)
+
+	return nil
+}
+
+func (ow *OrderWatcher) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := log.FromContext(ctx)
+	log.V(1).Info("Reconciling Order", "reconcile", req.String())
+
+	order, err := ow.certmanagerClient.AcmeV1().Orders(req.Namespace).Get(ctx, req.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			delete(ow.processedOrders, req.String())
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	if order.Status.State == "" || order.Status.State == acmev1.Pending {
+		return reconcile.Result{}, nil
+	}
+
+	orderKey := req.String()
+	if prevState, seen := ow.processedOrders[orderKey]; seen && prevState == order.Status.State {
+		return reconcile.Result{}, nil
+	}
+
+	gateway, err := ow.findGatewayForOrder(ctx, order)
+	if err != nil {
+		log.V(1).Info("Could not find gateway for order", "order", req.String(), "error", err)
+		return reconcile.Result{}, nil
+	}
+
+	if gateway == nil {
+		return reconcile.Result{}, nil
+	}
+
+	ow.processedOrders[orderKey] = order.Status.State
+
+	switch order.Status.State {
+	case acmev1.Valid:
+		ow.emitEvent(gateway, corev1.EventTypeNormal, ow.eventConfig.CertificateReadyReason,
+			fmt.Sprintf("Certificate for %s has been successfully issued", getDNSNamesFromOrder(order)))
+	case acmev1.Invalid, acmev1.Errored:
+		ow.emitEvent(gateway, corev1.EventTypeWarning, ow.eventConfig.CertificateFailedReason,
+			fmt.Sprintf("Certificate challenge failed for %s: %s", getDNSNamesFromOrder(order), order.Status.Reason))
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// findGatewayForOrder traverses the owner reference chain from Order -> CertificateRequest -> Certificate
+// to find the managed label that points back to the Gateway.
+func (ow *OrderWatcher) findGatewayForOrder(ctx context.Context, order *acmev1.Order) (interface{}, error) {
+	certReqRef := findOwnerRef(order.OwnerReferences, "CertificateRequest")
+	if certReqRef == nil {
+		return nil, fmt.Errorf("order has no CertificateRequest owner")
+	}
+
+	certReq, err := ow.certmanagerClient.CertmanagerV1().CertificateRequests(order.Namespace).Get(ctx, certReqRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	certRef := findOwnerRef(certReq.OwnerReferences, "Certificate")
+	if certRef == nil {
+		return nil, fmt.Errorf("certificate request has no Certificate owner")
+	}
+
+	cert, err := ow.certmanagerClient.CertmanagerV1().Certificates(order.Namespace).Get(ctx, certRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	managedLabel, ok := cert.Labels[v1beta1labels.ManagedLabel]
+	if !ok {
+		return nil, fmt.Errorf("certificate is not managed by this controller")
+	}
+
+	gatewayName, namespace := v1beta1labels.ParseManagedLabel(managedLabel)
+	if gatewayName == "" || namespace == "" {
+		return nil, fmt.Errorf("invalid managed label format: %s", managedLabel)
+	}
+
+	gateway, err := ow.istioClient.NetworkingV1beta1().Gateways(namespace).Get(ctx, gatewayName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return gateway, nil
+}
+
+func (ow *OrderWatcher) emitEvent(obj interface{}, eventType, reason, message string) {
+	if ow.dryRun {
+		return
+	}
+
+	if runtimeObj, ok := obj.(runtime.Object); ok {
+		ow.recorder.Event(runtimeObj, eventType, reason, message)
+	}
+}
+
+func findOwnerRef(refs []metav1.OwnerReference, kind string) *metav1.OwnerReference {
+	for i := range refs {
+		if refs[i].Kind == kind {
+			return &refs[i]
+		}
+	}
+	return nil
+}
+
+func getDNSNamesFromOrder(order *acmev1.Order) string {
+	if len(order.Spec.DNSNames) == 0 {
+		return "unknown"
+	}
+	return order.Spec.DNSNames[0]
+}

--- a/internal/controllers/v1beta1/orderwatcher/orderwatcher_test.go
+++ b/internal/controllers/v1beta1/orderwatcher/orderwatcher_test.go
@@ -1,0 +1,178 @@
+package orderwatcher
+
+import (
+	"context"
+	"testing"
+
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
+	certmanagerfake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestOrderWatcher_Reconcile_PendingOrderNoEvent(t *testing.T) {
+	order := &acmev1.Order{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-order",
+			Namespace: "test-ns",
+		},
+		Status: acmev1.OrderStatus{
+			State: acmev1.Pending,
+		},
+	}
+
+	cmc := certmanagerfake.NewSimpleClientset(order)
+	ic := istiofake.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	ow := NewOrderWatcher(cmc, ic, recorder)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      order.Name,
+			Namespace: order.Namespace,
+		},
+	}
+
+	_, err := ow.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+
+	select {
+	case event := <-recorder.Events:
+		t.Errorf("unexpected event for pending order: %s", event)
+	default:
+		// no event, as expected for pending order
+	}
+}
+
+func TestOrderWatcher_Reconcile_EmptyStateNoEvent(t *testing.T) {
+	order := &acmev1.Order{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-order",
+			Namespace: "test-ns",
+		},
+		Status: acmev1.OrderStatus{
+			State: "", // empty state
+		},
+	}
+
+	cmc := certmanagerfake.NewSimpleClientset(order)
+	ic := istiofake.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	ow := NewOrderWatcher(cmc, ic, recorder)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      order.Name,
+			Namespace: order.Namespace,
+		},
+	}
+
+	_, err := ow.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+
+	select {
+	case event := <-recorder.Events:
+		t.Errorf("unexpected event for empty state order: %s", event)
+	default:
+		// no event, as expected for empty state order
+	}
+}
+
+func TestOrderWatcher_Reconcile_NotFoundNoError(t *testing.T) {
+	cmc := certmanagerfake.NewSimpleClientset()
+	ic := istiofake.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	ow := NewOrderWatcher(cmc, ic, recorder)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "non-existent-order",
+			Namespace: "test-ns",
+		},
+	}
+
+	result, err := ow.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+	assert.False(t, result.Requeue)
+}
+
+func TestOrderWatcher_ProcessedOrdersDeduplication(t *testing.T) {
+	order := &acmev1.Order{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-order",
+			Namespace: "test-ns",
+		},
+		Spec: acmev1.OrderSpec{
+			DNSNames: []string{"test.example.com"},
+		},
+		Status: acmev1.OrderStatus{
+			State: acmev1.Valid,
+		},
+	}
+
+	cmc := certmanagerfake.NewSimpleClientset(order)
+	ic := istiofake.NewSimpleClientset()
+	recorder := record.NewFakeRecorder(10)
+
+	ow := NewOrderWatcher(cmc, ic, recorder)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      order.Name,
+			Namespace: order.Namespace,
+		},
+	}
+
+	// First reconcile - will fail to find gateway but should mark as processed
+	_, err := ow.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+
+	// Second reconcile - should be deduplicated since state hasn't changed
+	_, err = ow.Reconcile(context.Background(), req)
+	assert.NoError(t, err)
+
+	// processedOrders should not have changed since gateway wasn't found
+	// and no event was emitted (which is when we mark as processed)
+}
+
+func TestFindOwnerRef(t *testing.T) {
+	refs := []metav1.OwnerReference{
+		{Kind: "Certificate", Name: "cert-1"},
+		{Kind: "CertificateRequest", Name: "certreq-1"},
+	}
+
+	certRef := findOwnerRef(refs, "Certificate")
+	assert.NotNil(t, certRef)
+	assert.Equal(t, "cert-1", certRef.Name)
+
+	certReqRef := findOwnerRef(refs, "CertificateRequest")
+	assert.NotNil(t, certReqRef)
+	assert.Equal(t, "certreq-1", certReqRef.Name)
+
+	notFoundRef := findOwnerRef(refs, "NotFound")
+	assert.Nil(t, notFoundRef)
+}
+
+func TestGetDNSNamesFromOrder(t *testing.T) {
+	order := &acmev1.Order{
+		Spec: acmev1.OrderSpec{
+			DNSNames: []string{"test.example.com", "test2.example.com"},
+		},
+	}
+
+	result := getDNSNamesFromOrder(order)
+	assert.Equal(t, "test.example.com", result)
+
+	emptyOrder := &acmev1.Order{
+		Spec: acmev1.OrderSpec{},
+	}
+	result = getDNSNamesFromOrder(emptyOrder)
+	assert.Equal(t, "unknown", result)
+}

--- a/pkg/v1beta1/challengesolver/options.go
+++ b/pkg/v1beta1/challengesolver/options.go
@@ -7,3 +7,17 @@ func WithDryRun(dryrun bool) OptionsFunc {
 		cs.dryRun = dryrun
 	}
 }
+
+// FallbackIngressConfig holds configuration for creating Ingress resources
+// when DNS is not pointing to Istio (e.g., during migration from another ingress controller).
+type FallbackIngressConfig struct {
+	Enabled             bool
+	DNSDisabledAnnotation string
+	IngressClass        string
+}
+
+func WithFallbackIngress(cfg FallbackIngressConfig) OptionsFunc {
+	return func(cs *ChallengeSolver) {
+		cs.fallbackIngress = cfg
+	}
+}

--- a/pkg/v1beta1/challengesolver/solver.go
+++ b/pkg/v1beta1/challengesolver/solver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/adler32"
+	"strings"
 	"time"
 
 	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
@@ -16,15 +17,18 @@ import (
 	apinetv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	netapplymetav1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
 	netapplyv1beta1 "istio.io/client-go/pkg/applyconfiguration/networking/v1beta1"
+	istioversionedclient "istio.io/client-go/pkg/clientset/versioned"
 	networkingv1beta1Client "istio.io/client-go/pkg/clientset/versioned/typed/networking/v1beta1"
 
 	istiov1beta1 "istio.io/api/networking/v1beta1"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -40,17 +44,22 @@ type ChallengeSolver struct {
 	networkingClient  networkingv1beta1Client.NetworkingV1beta1Interface
 	acmeClient        acmev1Client.AcmeV1Interface
 	certmanagerClient certmanagerversionedclient.Interface
+	istioClient       istioversionedclient.Interface
+	k8sClient         kubernetes.Interface
 	glc               *cache.GatewayLookupCache
 	dryRun            bool
+	fallbackIngress   FallbackIngressConfig
 }
 
-func NewChallengeSolver(cc corev1listers.ServiceLister, nc networkingv1beta1Client.NetworkingV1beta1Interface, cmc certmanagerversionedclient.Interface, glc *cache.GatewayLookupCache, opts ...OptionsFunc) *ChallengeSolver {
+func NewChallengeSolver(cc corev1listers.ServiceLister, ic istioversionedclient.Interface, cmc certmanagerversionedclient.Interface, k8s kubernetes.Interface, glc *cache.GatewayLookupCache, opts ...OptionsFunc) *ChallengeSolver {
 
 	cs := &ChallengeSolver{
 		coreClient:        cc,
-		networkingClient:  nc,
+		networkingClient:  ic.NetworkingV1beta1(),
+		istioClient:       ic,
 		glc:               glc,
 		certmanagerClient: cmc,
+		k8sClient:         k8s,
 	}
 
 	cs.acmeClient = cs.certmanagerClient.AcmeV1()
@@ -120,6 +129,8 @@ func (cs *ChallengeSolver) Reconcile(ctx context.Context, req reconcile.Request)
 	return reconcile.Result{}, nil
 }
 
+// Solve creates the appropriate routing resource (Ingress or VirtualService) to route
+// ACME HTTP-01 challenge traffic to the cert-manager solver service.
 func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challenge) (*apinetv1beta1.VirtualService, error) {
 	log := log.FromContext(ctx)
 	log.V(1).Info("Debug")
@@ -168,6 +179,16 @@ func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challeng
 		UID:       challenge.UID,
 		Gateway:   namespacedGateway,
 	}
+
+	useFallbackIngress, err := cs.shouldUseFallbackIngress(ctx, namespacedGateway)
+	if err != nil {
+		return nil, err
+	}
+
+	if useFallbackIngress {
+		return nil, cs.createFallbackIngress(ctx, cm)
+	}
+
 	vsApply := VirtualServiceApplyFromChallengeMeta(cm)
 
 	// This controller is authoritative for these virtualservices so stomp any old versions that exist
@@ -177,6 +198,105 @@ func (cs *ChallengeSolver) Solve(ctx context.Context, challenge *acmev1.Challeng
 	}
 
 	return cs.networkingClient.VirtualServices(challenge.Namespace).Apply(ctx, vsApply, metav1.ApplyOptions{Force: true, FieldManager: "challengesolver"})
+}
+
+// shouldUseFallbackIngress checks if the Gateway has the DNS disabled annotation,
+// indicating that DNS is not pointing to Istio and we need to use a fallback Ingress.
+func (cs *ChallengeSolver) shouldUseFallbackIngress(ctx context.Context, namespacedGateway string) (bool, error) {
+	if !cs.fallbackIngress.Enabled {
+		return false, nil
+	}
+
+	parts := strings.SplitN(namespacedGateway, "/", 2)
+	if len(parts) != 2 {
+		return false, fmt.Errorf("invalid gateway format: %s", namespacedGateway)
+	}
+	namespace, name := parts[0], parts[1]
+
+	gateway, err := cs.istioClient.NetworkingV1beta1().Gateways(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get gateway %s: %w", namespacedGateway, err)
+	}
+
+	if val, ok := gateway.Annotations[cs.fallbackIngress.DNSDisabledAnnotation]; ok && val == "true" {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// createFallbackIngress creates a Kubernetes Ingress resource to route ACME challenge traffic
+// through a non-Istio ingress controller (e.g., Traefik) during migration scenarios.
+func (cs *ChallengeSolver) createFallbackIngress(ctx context.Context, cm ChallengeMeta) error {
+	log := log.FromContext(ctx)
+
+	ingress := IngressFromChallengeMeta(cm, cs.fallbackIngress.IngressClass)
+
+	if cs.dryRun {
+		log.Info(fmt.Sprintf("dry-run: creating Ingress %s/%s", ingress.Namespace, ingress.Name))
+		return nil
+	}
+
+	log.Info(fmt.Sprintf("Creating fallback Ingress %s/%s for challenge %s", ingress.Namespace, ingress.Name, cm.DNSName))
+
+	_, err := cs.k8sClient.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, metav1.CreateOptions{FieldManager: "challengesolver"})
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			_, err = cs.k8sClient.NetworkingV1().Ingresses(ingress.Namespace).Update(ctx, ingress, metav1.UpdateOptions{FieldManager: "challengesolver"})
+		}
+	}
+
+	return err
+}
+
+// IngressFromChallengeMeta creates a Kubernetes Ingress resource for routing ACME challenge traffic.
+func IngressFromChallengeMeta(cm ChallengeMeta, ingressClass string) *networkingv1.Ingress {
+	pathTypeExact := networkingv1.PathTypeExact
+
+	return &networkingv1.Ingress{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cm.Name,
+			Namespace: cm.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: acmev1.SchemeGroupVersion.String(),
+					Kind:       "Challenge",
+					Name:       cm.Name,
+					UID:        cm.UID,
+				},
+			},
+		},
+		Spec: networkingv1.IngressSpec{
+			IngressClassName: &ingressClass,
+			Rules: []networkingv1.IngressRule{
+				{
+					Host: cm.DNSName,
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     fmt.Sprintf("/.well-known/acme-challenge/%s", cm.Token),
+									PathType: &pathTypeExact,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: cm.Service,
+											Port: networkingv1.ServiceBackendPort{
+												Number: cm.Port,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 func (cs *ChallengeSolver) Hash(in string) string {

--- a/pkg/v1beta1/challengesolver/solver_test.go
+++ b/pkg/v1beta1/challengesolver/solver_test.go
@@ -16,6 +16,7 @@ import (
 
 	certmanagerfake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/fake"
 	acmefake "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned/typed/acme/v1/fake"
+	istiov1beta1 "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	networkingv1beta1fake "istio.io/client-go/pkg/clientset/versioned/typed/networking/v1beta1/fake"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
@@ -32,10 +34,11 @@ type testHelper struct {
 	ccs *certmanagerfake.Clientset
 	scs *fakeServiceLister
 	glc *cache.GatewayLookupCache
+	kcs *k8sfake.Clientset
 }
 
 func (th *testHelper) newTestSolver() *challengesolver.ChallengeSolver {
-	return challengesolver.NewChallengeSolver(th.scs, th.ics.NetworkingV1beta1(), th.ccs, th.glc)
+	return challengesolver.NewChallengeSolver(th.scs, th.ics, th.ccs, th.kcs, th.glc)
 }
 
 func TestChallengeSolver(t *testing.T) {
@@ -92,6 +95,7 @@ func TestChallengeSolver(t *testing.T) {
 			ccs: certmanagerfake.NewSimpleClientset(),
 			scs: &fakeServiceLister{Service: test.service},
 			glc: cache.New(),
+			kcs: k8sfake.NewSimpleClientset(),
 		}
 
 		th.ccs.AcmeV1().(*acmefake.FakeAcmeV1).PrependReactor(
@@ -214,4 +218,201 @@ func (s *stub) List(selector labels.Selector) ([]*corev1.Service, error) {
 
 func (s *stub) Get(name string) (*corev1.Service, error) {
 	return nil, nil
+}
+
+func TestFallbackIngress(t *testing.T) {
+	const (
+		dnsDisabledAnnotation = "test.example.com/dns-disabled"
+		ingressClass          = "traefik"
+	)
+
+	for _, test := range []struct {
+		name              string
+		challenge         *acmev1.Challenge
+		service           *corev1.Service
+		gateway           *networkingv1beta1.Gateway
+		fallbackEnabled   bool
+		expectIngress     bool
+		expectVS          bool
+		pass              bool
+	}{
+		{
+			name:            "fallback disabled creates VirtualService",
+			challenge:       getChallenge("test-challenge", "example", "test.example.com"),
+			service:         getService("solver-svc", "example", "test.example.com", 8089),
+			gateway:         getGateway("test-gateway", "example", nil),
+			fallbackEnabled: false,
+			expectIngress:   false,
+			expectVS:        true,
+			pass:            true,
+		},
+		{
+			name:            "fallback enabled but annotation not present creates VirtualService",
+			challenge:       getChallenge("test-challenge", "example", "test.example.com"),
+			service:         getService("solver-svc", "example", "test.example.com", 8089),
+			gateway:         getGateway("test-gateway", "example", nil),
+			fallbackEnabled: true,
+			expectIngress:   false,
+			expectVS:        true,
+			pass:            true,
+		},
+		{
+			name:      "fallback enabled with dns-disabled annotation creates Ingress",
+			challenge: getChallenge("test-challenge", "example", "test.example.com"),
+			service:   getService("solver-svc", "example", "test.example.com", 8089),
+			gateway: getGateway("test-gateway", "example", map[string]string{
+				dnsDisabledAnnotation: "true",
+			}),
+			fallbackEnabled: true,
+			expectIngress:   true,
+			expectVS:        false,
+			pass:            true,
+		},
+		{
+			name:      "fallback enabled with dns-disabled=false creates VirtualService",
+			challenge: getChallenge("test-challenge", "example", "test.example.com"),
+			service:   getService("solver-svc", "example", "test.example.com", 8089),
+			gateway: getGateway("test-gateway", "example", map[string]string{
+				dnsDisabledAnnotation: "false",
+			}),
+			fallbackEnabled: true,
+			expectIngress:   false,
+			expectVS:        true,
+			pass:            true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ics := istiofake.NewSimpleClientset()
+
+			th := testHelper{
+				ics: ics,
+				ccs: certmanagerfake.NewSimpleClientset(),
+				scs: &fakeServiceLister{Service: test.service},
+				glc: cache.New(),
+				kcs: k8sfake.NewSimpleClientset(),
+			}
+
+			th.ccs.AcmeV1().(*acmefake.FakeAcmeV1).PrependReactor(
+				"get",
+				"challenges",
+				getChallengeFunc(test.challenge))
+
+			if test.gateway != nil {
+				th.glc.Add(fmt.Sprintf("%s/%s", test.gateway.Namespace, test.gateway.Name), test.challenge.Spec.DNSName)
+
+				th.ics.NetworkingV1beta1().(*networkingv1beta1fake.FakeNetworkingV1beta1).PrependReactor(
+					"get",
+					"gateways",
+					func(action k8stesting.Action) (bool, runtime.Object, error) {
+						return true, test.gateway, nil
+					})
+			}
+
+			vs := networkingv1beta1.VirtualService{}
+			vs.Name = test.challenge.Name
+			vs.Namespace = test.challenge.Namespace
+			th.ics.NetworkingV1beta1().(*networkingv1beta1fake.FakeNetworkingV1beta1).PrependReactor(
+				"patch",
+				"virtualservices",
+				func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, &vs, nil
+				})
+
+			opts := []challengesolver.OptionsFunc{}
+			if test.fallbackEnabled {
+				opts = append(opts, challengesolver.WithFallbackIngress(challengesolver.FallbackIngressConfig{
+					Enabled:               true,
+					DNSDisabledAnnotation: dnsDisabledAnnotation,
+					IngressClass:          ingressClass,
+				}))
+			}
+
+			cs := challengesolver.NewChallengeSolver(th.scs, th.ics, th.ccs, th.kcs, th.glc, opts...)
+
+			out, err := cs.Solve(context.Background(), test.challenge)
+
+			if test.pass {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+
+			if test.expectVS {
+				assert.NotNil(t, out, "expected VirtualService to be created")
+			} else {
+				assert.Nil(t, out, "expected no VirtualService")
+			}
+
+			if test.expectIngress {
+				ingresses, err := th.kcs.NetworkingV1().Ingresses(test.challenge.Namespace).List(context.Background(), metav1.ListOptions{})
+				assert.NoError(t, err)
+				assert.Len(t, ingresses.Items, 1, "expected one Ingress to be created")
+
+				if len(ingresses.Items) > 0 {
+					ingress := ingresses.Items[0]
+					assert.Equal(t, test.challenge.Name, ingress.Name)
+					assert.Equal(t, ingressClass, *ingress.Spec.IngressClassName)
+					assert.Len(t, ingress.Spec.Rules, 1)
+					assert.Equal(t, test.challenge.Spec.DNSName, ingress.Spec.Rules[0].Host)
+					assert.Contains(t, ingress.Spec.Rules[0].HTTP.Paths[0].Path, "/.well-known/acme-challenge/")
+				}
+			}
+		})
+	}
+}
+
+func TestIngressFromChallengeMeta(t *testing.T) {
+	cm := challengesolver.ChallengeMeta{
+		Port:      8089,
+		Service:   "solver-svc",
+		DNSName:   "test.example.com",
+		Namespace: "test-ns",
+		Token:     "test-token-123",
+		Name:      "test-challenge",
+		UID:       types.UID("uid-12345"),
+		Gateway:   "test-ns/test-gateway",
+	}
+
+	ingress := challengesolver.IngressFromChallengeMeta(cm, "traefik")
+
+	assert.Equal(t, "test-challenge", ingress.Name)
+	assert.Equal(t, "test-ns", ingress.Namespace)
+	assert.Equal(t, "traefik", *ingress.Spec.IngressClassName)
+
+	assert.Len(t, ingress.OwnerReferences, 1)
+	assert.Equal(t, "Challenge", ingress.OwnerReferences[0].Kind)
+	assert.Equal(t, "test-challenge", ingress.OwnerReferences[0].Name)
+	assert.Equal(t, types.UID("uid-12345"), ingress.OwnerReferences[0].UID)
+
+	assert.Len(t, ingress.Spec.Rules, 1)
+	assert.Equal(t, "test.example.com", ingress.Spec.Rules[0].Host)
+	assert.Equal(t, "/.well-known/acme-challenge/test-token-123", ingress.Spec.Rules[0].HTTP.Paths[0].Path)
+	assert.Equal(t, "solver-svc", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
+	assert.Equal(t, int32(8089), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+}
+
+func getGateway(name, namespace string, annotations map[string]string) *networkingv1beta1.Gateway {
+	return &networkingv1beta1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Gateway",
+			APIVersion: "networking.istio.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: istiov1beta1.Gateway{
+			Servers: []*istiov1beta1.Server{
+				{
+					Hosts: []string{"test.example.com"},
+					Port: &istiov1beta1.Port{
+						Number:   443,
+						Name:     "https",
+						Protocol: "HTTPS",
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Adds support for using a kubernetes ingress in place of an istio gateway depending on an annotation. This can be used to solve chicken and egg problems when migrating a domain to istio without breaking routing during the migration. The annotation value denotes that DNS is not pointed to istio and that the gateway will not receive traffic. Instead of creating a virtualservice, the gateway controller will create an ingress that routes to the challenge solver service. Additionally, an orderwatcher controller watches orders for resolution and emits events. This can be used to detect when a certificate has been solved.